### PR TITLE
Dockerize

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+bin
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,60 @@
+# Build modwt
+FROM alpine as modwt-build
+RUN apk update
+RUN apk add \
+  g++ \
+  git \
+  make
+RUN git clone https://github.com/StamLab/modwt.git \
+      && cd modwt \
+      && git checkout 28e9f479c737836ffc870199f2468e30659ab38d \
+      && make
+
+# Build samtools
+FROM alpine as samtools-build
+RUN apk update \
+    && apk add \
+    autoconf \
+    g++ \
+    git \
+    bzip2-dev \
+    make \
+    ncurses-dev \
+    xz-dev \
+    zlib-dev
+RUN wget https://github.com/samtools/samtools/releases/download/1.7/samtools-1.7.tar.bz2 \
+      && tar xf samtools-1.7.tar.bz2 \
+      && cd samtools-1.7 \
+      && make install
+
+# Build hotspot2
+FROM alpine as hotspot2-build
+RUN apk update
+RUN apk add \
+      bash \
+      g++ \
+      make
+WORKDIR /hotspot2
+ADD . .
+RUN make
+
+# Build the final container
+FROM alpine as hotspot2
+# Install dynamic libraries
+RUN apk update \
+      && apk add \
+      bash \
+      bzip2-dev \
+      ncurses \
+      xz-dev \
+      zlib-dev
+# Get bedops
+RUN wget -O - https://github.com/bedops/bedops/releases/download/v2.4.31/bedops_linux_x86_64-v2.4.31.tar.bz2 \
+  | tar -C /usr/local -xjf -
+# Get bedgraph2BigWig
+RUN cd /usr/local/bin && wget http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/bedGraphToBigWig
+# Get built files
+COPY --from=modwt-build /modwt/bin/ /usr/local/bin
+COPY --from=samtools-build /usr/local/bin /usr/local/bin
+COPY --from=hotspot2-build /hotspot2/bin/ /usr/local/bin/
+COPY --from=hotspot2-build /hotspot2/scripts/ /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ FROM alpine:3.7 as hotspot2
 # Install dynamic libraries
 RUN apk add --no-cache \
       bash \
+      bc \
       bzip2-dev \
       ncurses \
       xz-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ RUN apk add --no-cache \
       bash \
       bc \
       bzip2-dev \
+      coreutils \
       ncurses \
       xz-dev \
       zlib-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,11 @@ RUN wget -O - https://github.com/bedops/bedops/releases/download/v2.4.31/bedops_
   | tar -C /usr/local -xjf -
 # Get built files
 COPY --from=kentutils-build /kentUtils-302.0.0/bin/bedGraphToBigWig /usr/local/bin/
+COPY --from=kentutils-build /kentUtils-302.0.0/bin/bedToBigBed /usr/local/bin/
+
 COPY --from=modwt-build /modwt/bin/ /usr/local/bin/
+
 COPY --from=samtools-build /usr/local/bin /usr/local/bin/
+
 COPY --from=hotspot2-build /hotspot2/bin/ /usr/local/bin/
 COPY --from=hotspot2-build /hotspot2/scripts/ /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 # Build modwt
-FROM alpine as modwt-build
-RUN apk update
-RUN apk add \
+FROM alpine:3.7 as modwt-build
+RUN apk add --no-cache \
   g++ \
   git \
   make
@@ -11,9 +10,8 @@ RUN git clone https://github.com/StamLab/modwt.git \
       && make
 
 # Build samtools
-FROM alpine as samtools-build
-RUN apk update \
-    && apk add \
+FROM alpine:3.7 as samtools-build
+RUN apk add --no-cache \
     autoconf \
     g++ \
     git \
@@ -28,9 +26,8 @@ RUN wget https://github.com/samtools/samtools/releases/download/1.7/samtools-1.7
       && make install
 
 # Build hotspot2
-FROM alpine as hotspot2-build
-RUN apk update
-RUN apk add \
+FROM alpine:3.7 as hotspot2-build
+RUN apk add --no-cache \
       bash \
       g++ \
       make
@@ -39,9 +36,8 @@ ADD . .
 RUN make
 
 # Build bedGraphToBigWig
-FROM alpine as kentutils-build
-RUN apk update \
-      && apk add \
+FROM alpine:3.7 as kentutils-build
+RUN apk add --no-cache \
       g++ \
       gcc \
       git \
@@ -49,7 +45,6 @@ RUN apk update \
       make \
       mysql-dev \
       zlib-dev
-
 # Get an archive of kentUtils, remove a file that doesn't build, and compile
 RUN wget https://github.com/ENCODE-DCC/kentUtils/archive/v302.0.0.tar.gz \
       && tar xf v302.0.0.tar.gz \
@@ -58,10 +53,9 @@ RUN wget https://github.com/ENCODE-DCC/kentUtils/archive/v302.0.0.tar.gz \
       && make
 
 # Build the final container
-FROM alpine as hotspot2
+FROM alpine:3.7 as hotspot2
 # Install dynamic libraries
-RUN apk update \
-      && apk add \
+RUN apk add --no-cache \
       bash \
       bzip2-dev \
       ncurses \


### PR DESCRIPTION
This adds a Dockerfile to create a hotspot2 docker container.

# Usage

    docker run --mount type=bind,source="$(pwd)"/data,target=/data -it hotspot2 extractCenterSites.sh -c /data/chr20.chrom_sizes.bed -o /data/chr20.chrom_sizes.center.starch
    docker run --mount type=bind,source="$(pwd)"/data,target=/data -it hotspot2 hotspot2.sh -c /data/chr20.chrom_sizes.bed -C /data/chr20.chrom_sizes.center.starch /data/chr20.bam /data/out_chr20

Where the current directory has:
* `./data/chr20.chrom_sizes.bed`
* ` ./data/chr20.bam`

and will create:
* `./data/chr20.chrom_sizes.center.starch`
* `./data/out_chr20/chr20.allcalls.starch`
* `./data/out_chr20/chr20.cleavage.total`
* `./data/out_chr20/chr20.cutcounts.starch`
* `./data/out_chr20/chr20.density.bw`
* `./data/out_chr20/chr20.density.starch`
* `./data/out_chr20/chr20.fragments.sorted.starch`
* `./data/out_chr20/chr20.hotspots.fdr0.05.starch`
* `./data/out_chr20/chr20.peaks.narrowpeaks.starch`
* `./data/out_chr20/chr20.peaks.starch`
* `./data/out_chr20/chr20.SPOT.txt`

# Docker trivia

`.dockerignore` is a file much like `.gitignore` - files matching these patterns are not sent as context to the docker daemon.

this `Dockerfile` uses a multi-stage build approach. This builds several small sub-images (`modwt-build`, `samtools-build`, etc), to compile the code necessary.  The final stage copies only the necessary tools out of the previous stages, resulting in a lean image size of 75MB.

